### PR TITLE
Fix ansible-lint errors

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Add additional sudoers Permissions.
   template:
-    dest: "/etc/sudoers.d/{{ item.filename}}"
+    dest: "/etc/sudoers.d/{{ item.filename }}"
     src: custom_sudoers.j2
     mode: 0440
     owner: root
@@ -47,7 +47,7 @@
 
 - name: Remove additional sudoers Permissions.
   file:
-    path: "/etc/sudoers.d/{{ item.filename}}"
+    path: "/etc/sudoers.d/{{ item.filename }}"
     state: "{{ item.state }}"
   when: sudo_sudoers_config is defined and item.state == "absent"
   with_items:


### PR DESCRIPTION
```
find ./ -name '*.yml' -exec $SHELL -c 'ansible-lint "$0" -x 204,602' {} \;

[206] Variables should have spaces before and after: {{ var_name }}
ansible-role-sudo/tasks/main.yml:38
    dest: "/etc/sudoers.d/{{ item.filename}}"

[206] Variables should have spaces before and after: {{ var_name }}
ansible-role-sudo/tasks/main.yml:50
    path: "/etc/sudoers.d/{{ item.filename}}"
```